### PR TITLE
battleIconのロードをrepositoryとして分離、必要な分だけロードするように変更

### DIFF
--- a/Dotkun.xcodeproj/project.pbxproj
+++ b/Dotkun.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		550D20BE1BEB6B0400B6EC4A /* BattleIconCollectionCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 550D20BD1BEB6B0400B6EC4A /* BattleIconCollectionCell.swift */; };
 		550D20E41BEE5F2400B6EC4A /* ColorPickerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 550D20E31BEE5F2400B6EC4A /* ColorPickerViewController.swift */; };
+		555DAA7E1BEEED93006F00B0 /* BattleIconRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 555DAA7D1BEEED93006F00B0 /* BattleIconRepository.swift */; };
 		558032C11BE77F54001D9C61 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 558032C01BE77F54001D9C61 /* Constants.swift */; };
 		55BF3B2F1BE9DD5400AF67AC /* BaseViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55BF3B2C1BE9DD5400AF67AC /* BaseViewController.swift */; };
 		55BF3B301BE9DD5400AF67AC /* TabBarSlaveViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55BF3B2D1BE9DD5400AF67AC /* TabBarSlaveViewController.swift */; };
@@ -62,6 +63,7 @@
 		1F264AC49FB783E0CC7239C3 /* Pods.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		550D20BD1BEB6B0400B6EC4A /* BattleIconCollectionCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BattleIconCollectionCell.swift; sourceTree = "<group>"; };
 		550D20E31BEE5F2400B6EC4A /* ColorPickerViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ColorPickerViewController.swift; sourceTree = "<group>"; };
+		555DAA7D1BEEED93006F00B0 /* BattleIconRepository.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BattleIconRepository.swift; sourceTree = "<group>"; };
 		558032C01BE77F54001D9C61 /* Constants.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
 		55BF3B2C1BE9DD5400AF67AC /* BaseViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BaseViewController.swift; sourceTree = "<group>"; };
 		55BF3B2D1BE9DD5400AF67AC /* TabBarSlaveViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TabBarSlaveViewController.swift; sourceTree = "<group>"; };
@@ -238,6 +240,7 @@
 				FA01F4F51BE75F66003B738C /* Dotkun.swift */,
 				FA01F4FA1BE76206003B738C /* User.swift */,
 				FA1E919B1BE9C1EB00566A94 /* BattleIcon.swift */,
+				555DAA7D1BEEED93006F00B0 /* BattleIconRepository.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -494,6 +497,7 @@
 				FA1E92061BEB5BE000566A94 /* GameUtils.swift in Sources */,
 				55F33D4D1BE8515A007A73E5 /* ProfileViewController.swift in Sources */,
 				FA1E91B01BE9CEC600566A94 /* CreateBattleIconViewController.swift in Sources */,
+				555DAA7E1BEEED93006F00B0 /* BattleIconRepository.swift in Sources */,
 				FA1E91A71BE9CD5A00566A94 /* SelectGameViewController.swift in Sources */,
 				FA1E91AB1BE9CD8100566A94 /* GameView.swift in Sources */,
 				55F33D4B1BE8510E007A73E5 /* HomeTabBarController.swift in Sources */,

--- a/Dotkun/Model/BattleIcon.swift
+++ b/Dotkun/Model/BattleIcon.swift
@@ -13,7 +13,7 @@ import RealmSwift
 class BattleIcon: Object {
     static let realm = try! Realm()
     
-    dynamic private var id = 0
+    dynamic var id = 0
     
     dynamic private var _image: UIImage?
     dynamic var image: UIImage? {
@@ -36,14 +36,6 @@ class BattleIcon: Object {
     }
     dynamic private var imageData: NSData?
     
-    override static func primaryKey() -> String? {
-        return "id"
-    }
-    
-    override static func ignoredProperties() -> [String] {
-        return ["image", "_image"]
-    }
-    
     static func new(image: UIImage?) -> BattleIcon {
         let icon = BattleIcon()
         icon.image = image!
@@ -54,20 +46,19 @@ class BattleIcon: Object {
         return icon
     }
     
-    static func loadAll() -> [BattleIcon] {
-        let battleIcons = realm.objects(BattleIcon).sorted("id", ascending: false)
-        var ret: [BattleIcon] = []
-        for battleIcon in battleIcons {
-            ret.append(battleIcon)
-        }
-        return ret
-    }
-    
     static func lastId() -> Int {
         if let user = realm.objects(BattleIcon).last {
             return user.id + 1
         } else {
             return 1
         }
+    }
+    
+    override static func primaryKey() -> String? {
+        return "id"
+    }
+    
+    override static func ignoredProperties() -> [String] {
+        return ["image", "_image"]
     }
 }

--- a/Dotkun/Model/BattleIconRepository.swift
+++ b/Dotkun/Model/BattleIconRepository.swift
@@ -1,0 +1,45 @@
+//
+//  BattleIconRepository.swift
+//  Dotkun
+//
+//  Created by 山口智生 on 2015/11/08.
+//  Copyright © 2015年 SakuragiYoshimasa. All rights reserved.
+//
+
+import UIKit
+import RealmSwift
+
+class BattleIconRepository {
+    
+    private var battleIcons: [BattleIcon] = []
+    
+    func reload() {
+        let realm = BattleIcon.realm
+        
+        if let lastId = self.battleIcons.first?.id {
+            // 新しいデータのみロード、古い順に前に追加
+            let loadedData = realm.objects(BattleIcon).filter("id > \(lastId)").sorted("id", ascending: true)
+            for battleIcon in loadedData {
+                self.battleIcons.insert(battleIcon, atIndex: 0)
+            }
+        } else {
+            // はじめだけ、新しい順にすべてのデータをロード
+            let loadedData = realm.objects(BattleIcon).sorted("id", ascending: false)
+            for battleIcon in loadedData {
+                self.battleIcons.append(battleIcon)
+            }
+        }
+    }
+    
+    func getAll() -> [BattleIcon] {
+        self.reload()
+        return self.battleIcons
+    }
+    
+    func get(index: Int) -> BattleIcon {
+        return self.battleIcons[index]
+    }
+    func getBattleIconCount() -> Int {
+        return self.battleIcons.count
+    }
+}

--- a/Dotkun/ViewController/BattleiconCollectionViewController/BattleIconCollectionViewController.swift
+++ b/Dotkun/ViewController/BattleiconCollectionViewController/BattleIconCollectionViewController.swift
@@ -15,18 +15,10 @@ class BattleIconCollectionViewController: TabBarSlaveViewController {
     
     var battleIconCollection: UICollectionView! = nil
     
-    var battleIcons: [BattleIcon] = []
-    
-    
-    static func sampleBattleIcon() -> BattleIcon {
-        let battleIcon = BattleIcon()
-        battleIcon.image = UIImage(named: "ha1f.png")
-        return battleIcon
-    }
+    var battleIconRepository: BattleIconRepository! = nil
     
     override func viewWillAppear(animated: Bool) {
-        print("appear")
-        battleIcons = BattleIcon.loadAll()
+        battleIconRepository.reload()
         self.battleIconCollection.reloadData()
     }
     
@@ -53,6 +45,10 @@ class BattleIconCollectionViewController: TabBarSlaveViewController {
             battleIconCollection.registerClass(BattleIconCollectionCell.self, forCellWithReuseIdentifier: "BattleIconCollectionCell")
             self.view.addSubview(battleIconCollection)
         }
+        
+        if battleIconRepository == nil {
+            battleIconRepository = BattleIconRepository()
+        }
     }
     
     func createIcon() {
@@ -69,14 +65,14 @@ extension BattleIconCollectionViewController: UICollectionViewDataSource, UIColl
     func collectionView(collectionView: UICollectionView, cellForItemAtIndexPath indexPath: NSIndexPath) -> UICollectionViewCell {
         
         let cell = collectionView.dequeueReusableCellWithReuseIdentifier("BattleIconCollectionCell", forIndexPath: indexPath) as! BattleIconCollectionCell
-        cell.setup(battleIcons[indexPath.row])
+        cell.setup(battleIconRepository.get(indexPath.row))
         
         return cell
     }
     
     func collectionView(collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAtIndexPath indexPath: NSIndexPath) -> CGSize {
         
-        let size: CGSize = CGSizeMake(100, 100)
+        let size: CGSize = CGSizeMake(90, 90)
         
         return size
     }
@@ -94,6 +90,6 @@ extension BattleIconCollectionViewController: UICollectionViewDataSource, UIColl
     }
     
     func collectionView(collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        return battleIcons.count
+        return battleIconRepository.getBattleIconCount()
     }
 }


### PR DESCRIPTION
battleIconのロードをrepositoryとして分離
battleIconロード時、必要な分だけロードするように変更
iPhone 5sでもいい感じにbattleIconのcollectionが見れるようにセルのサイズを縮小

@SakuragiYoshimasa 
